### PR TITLE
Add ability to configure host

### DIFF
--- a/lib/api2cart.rb
+++ b/lib/api2cart.rb
@@ -1,3 +1,5 @@
+require 'active_support/configurable'
+
 require 'api2cart/request_url_composer'
 require 'api2cart/client'
 require 'api2cart/store'
@@ -5,4 +7,9 @@ require 'api2cart/errors'
 require 'api2cart/error_class_recognizer'
 
 module Api2cart
+  include ActiveSupport::Configurable
+
+  config_accessor :host do
+    'api.api2cart.com'
+  end
 end

--- a/lib/api2cart/request_url_composer.rb
+++ b/lib/api2cart/request_url_composer.rb
@@ -3,14 +3,17 @@ require 'active_support/core_ext/object/to_query'
 
 module Api2cart
   class RequestUrlComposer < Struct.new(:api_key, :store_key, :method_name, :query_params)
-    HOST = 'api.api2cart.com'
     PATH_BASE = '/v1.0'
 
     def compose_request_url
-      URI::HTTP.build host: HOST, path: full_path, query: query_string
+      URI::HTTP.build host: host, path: full_path, query: query_string
     end
 
     protected
+
+    def host
+      Api2cart.host
+    end
 
     def full_path
       "#{PATH_BASE}/#{dotted_method_name}.json"

--- a/spec/api2cart/configuration_spec.rb
+++ b/spec/api2cart/configuration_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Api2cart, '#host' do
+  context 'when host is not configured' do
+    it 'should be equal to default value' do
+      expect(Api2cart.host).to eq 'api.api2cart.com'
+    end
+  end
+
+  context 'when host is configured' do
+    let!(:current_host) { Api2cart.host }
+
+    before { Api2cart.configure{ |config| config.host = 'host.com' } }
+
+    it 'should be equal to new host' do
+      expect(Api2cart.host).to eq 'host.com'
+    end
+
+    after { Api2cart.configure{ |config| config.host = current_host } }
+  end
+end

--- a/spec/api2cart/request_url_composer_spec.rb
+++ b/spec/api2cart/request_url_composer_spec.rb
@@ -24,8 +24,22 @@ describe Api2cart::RequestUrlComposer do
   describe 'domain' do
     subject { composed_url.host }
 
-    specify do
-      expect(subject).to eq('api.api2cart.com')
+    context 'when host is default' do
+      specify do
+        expect(subject).to eq('api.api2cart.com')
+      end
+    end
+
+    context 'when host is configured' do
+      let!(:current_host) { Api2cart.host }
+
+      before { Api2cart.configure{ |config| config.host = 'host.com' } }
+
+      specify do
+        expect(subject).to eq('host.com')
+      end
+
+      after { Api2cart.configure{ |config| config.host = current_host } }
     end
   end
 
@@ -64,8 +78,22 @@ describe Api2cart::RequestUrlComposer do
   describe 'all together' do
     subject { composed_url.to_s }
 
-    it do
-      is_expected.to eq 'http://api.api2cart.com/v1.0/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
+    context 'when host is default' do
+      it do
+        is_expected.to eq 'http://api.api2cart.com/v1.0/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
+      end
+    end
+
+    context 'when host is configured' do
+      let!(:current_host) { Api2cart.host }
+
+      before { Api2cart.configure{ |config| config.host = 'host.com' } }
+
+      it do
+        is_expected.to eq 'http://host.com/v1.0/order.list.json?api_key=43ba7043badfa2cd31cfaf5dc601a884&count=10&params=force_all&start=20&store_key=6f00bbf49f5ada8156506aba161408c6'
+      end
+
+      after { Api2cart.configure{ |config| config.host = current_host } }
     end
   end
 


### PR DESCRIPTION
When user buys dedicated server from api2cart he has to use own host to make requests.
Here added ability to configure host, leaving 'api.api2cart.com' as default.